### PR TITLE
OrdersApi-->OrdersAPI

### DIFF
--- a/apis/order/package.json
+++ b/apis/order/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "OrderApi",
+  "name": "OrderAPI",
   "version": "1.0.0",
   "repository": "https://github.com/marcusoftnet/UserApiWithTest",
   "description": "The order API",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/marcusoftnet/UserApiWithTest",
   "dependencies": {
     "AddressAPI": "file:apis/address",
-    "OrderApi": "file:apis/order",
+    "OrderAPI": "file:apis/order",
     "UserAPI": "file:apis/user",
     "koa": "^0.20.0",
     "koa-basic-auth": "^1.1.2",


### PR DESCRIPTION
Rename OrderApi to OrderAPI in 2 package.json files, otherwise test on Ubuntu not passing ("can't find OrderAPI module", bcs npm install made "./node_modules/OrderApi" 
